### PR TITLE
Update LAYERSERIES_COMPAT with warrior

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-conan = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-conan = "6"
 
 LAYERDEPENDS_meta-conan = "core meta-python"
-LAYERSERIES_COMPAT_meta-conan = "thud"
+LAYERSERIES_COMPAT_meta-conan = "warrior"


### PR DESCRIPTION
ERROR: Layer meta-conan is not compatible with the core layer which only supports these series: warrior (layer is compatible with thud)