### PR TITLE
enable network access during do_install

### DIFF
--- a/classes/conan.bbclass
+++ b/classes/conan.bbclass
@@ -34,6 +34,7 @@ def map_yocto_arch_to_conan_arch(d, arch_var):
     print("Arch value '{}' from '{}' mapped to '{}'".format(arch, arch_var, ret))
     return ret
 
+do_install[network] = "1"
 conan_do_install() {
     rm -rf ${WORKDIR}/.conan
     if [ ${CONAN_CONFIG_URL} ]; then


### PR DESCRIPTION
since 'conan install' wants to access "CONAN_REMOTE_URL" on during the fakeroot-ed do_install task, network access has to be specifically granted

a better solution might be to split the configuration setup, package download off into a separate task - like do_fetch? (-:
and only to the conan install during do_install to unpack the binaries 