### PR TITLE
Don't set the conan user if no CONAN_USER is given

### DIFF
--- a/classes/conan.bbclass
+++ b/classes/conan.bbclass
@@ -74,10 +74,12 @@ EOF
     echo ${CONAN_PROFILE_PATH}
     conan profile show ${CONAN_PROFILE_PATH}
 
-    for NAME in ${CONAN_REMOTE_NAME}
-    do
-        conan user -p ${CONAN_PASSWORD} -r ${NAME} ${CONAN_USER}
-    done
+    if [ "${CONAN_USER}" ]; then
+        for NAME in ${CONAN_REMOTE_NAME}
+        do
+            conan user -p ${CONAN_PASSWORD} -r ${NAME} ${CONAN_USER}
+        done
+    fi
     conan install ${CONAN_PKG} --profile ${CONAN_PROFILE_PATH} -if ${D}
     rm -f ${D}/deploy_manifest.txt
 }


### PR DESCRIPTION
Apply #29 to honister. Supports unauthenticated Conan repositories by not attempting to login unless CONAN_USER is set.