### PR TITLE
Add support for Conan 2.x

### DIFF
--- a/classes/conan.bbclass
+++ b/classes/conan.bbclass
@@ -34,6 +34,7 @@ def map_yocto_arch_to_conan_arch(d, arch_var):
     print("Arch value '{}' from '{}' mapped to '{}'".format(arch, arch_var, ret))
     return ret
 
+do_install[network] = "1"
 conan_do_install() {
     rm -rf ${WORKDIR}/.conan
     if [ ${CONAN_CONFIG_URL} ]; then
@@ -72,16 +73,18 @@ EOF
 
     echo "Using profile:"
     echo ${CONAN_PROFILE_PATH}
-    conan profile show ${CONAN_PROFILE_PATH}
+    conan profile show -pr ${CONAN_PROFILE_PATH}
 
     if [ "${CONAN_USER}" ]; then
         for NAME in ${CONAN_REMOTE_NAME}
         do
-            conan user -p ${CONAN_PASSWORD} -r ${NAME} ${CONAN_USER}
+            conan remote login -p "${CONAN_PASSWORD}" "${NAME}" "${CONAN_USER}"
         done
     fi
-    conan install ${CONAN_PKG} --profile ${CONAN_PROFILE_PATH} -if ${D}
+    conan install --requires=${CONAN_PKG} --profile ${CONAN_PROFILE_PATH} -of ${D}
     rm -f ${D}/deploy_manifest.txt
+    rm -f ${D}/deactivate_*.sh
+    rm -f ${D}/conan*.sh
 }
 
 EXPORT_FUNCTIONS do_compile do_install

--- a/recipes-devtools/python3-conan_2.0.11.bb
+++ b/recipes-devtools/python3-conan_2.0.11.bb
@@ -1,11 +1,11 @@
 SUMMARY = "Conan C/C++ package manager"
 HOMEPAGE = "https://conan.io"
-AUTHOR = "JFrog LTD <luism@jfrog.com>"
+AUTHOR = "JFrog LTD <info@conan.io>"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=1e486b3d16485847635c786d2b7bd32a"
 
-SRC_URI[md5sum] = "bf8f76b70de869b167a739d75f7b46dd"
-SRC_URI[sha256sum] = "11ed86b8f6ddf83d48a8a2a8688c2b24b7a391b3d7dd7a3dd2cde7650b11a955"
+SRC_URI[md5sum] = "00e7631ca11eeb3d8072f4586aaf1196"
+SRC_URI[sha256sum] = "f9129ae26c4e025c344e7d34e2afaedc924298da6810136a2b7e542143c6638c"
 
 inherit setuptools3 python3-dir pypi update-alternatives
 


### PR DESCRIPTION
First step towards Conan 2.x support, but need to keep retro-compatibility with 1.x, just in case.

- [ ] TODO: Check Conan version and execute supported conan command only.

closes #44