### PR TITLE
[ci] Add minimal yocto image build

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,57 +1,32 @@
-# Use Ubuntu 18.04 LTS (Bionic Beaver) as the basis for the Docker image.
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
-# Install all Linux packages required for Yocto builds as given in section "Build Host Packages"
-# on https://www.yoctoproject.org/docs/3.0.2/brief-yoctoprojectqs/brief-yoctoprojectqs.html.
-# I added the package git-lfs, which I found missing during a Yocto build.
-# Without DEBIAN_FRONTEND=noninteractive, the image build hangs indefinitely
-# at "Configuring tzdata". Even if you answer the question about the time zone, it will
-# not proceed.
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
-    gawk wget git-core diffstat unzip texinfo gcc-multilib \
-    build-essential chrpath socat cpio python python3 python3-pip python3-pexpect \
-    xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev \
-    pylint3 xterm git-lfs
 
-# These packages are not needed for the Yocto build but in this file below.
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
-    locales sudo
+RUN apt-get -qq update \
+    && apt-get -qq install -y --no-install-recommends --no-install-suggests \
+       git \
+       python3 \
+       python3-dev \
+       build-essential \
+       chrpath \
+       cpio \
+       diffstat \
+       file \
+       gawk \
+       wget \
+       lz4 \
+       zstd \
+       sudo \
+       locales \
+    && locale-gen en_US.UTF-8 \
+    && update-locale LANG=en_US.UTF-8 \
+    && groupadd _1001 -g 1001 \
+    && groupadd _1000 -g 1000 \
+    && groupadd _2000 -g 2000 \
+    && groupadd _999 -g 999 \
+    && useradd -ms /bin/bash conan -g _1001 -G _1000,_2000,_999 \
+    && printf "conan:conan" | chpasswd \
+    && adduser conan sudo \
+    && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers
 
-# By default, Ubuntu uses dash as an alias for sh. Dash does not support the source command
-# needed for setting up Yocto build environments. Use bash as an alias for sh.
-RUN which dash &> /dev/null && (\
-    echo "dash dash/sh boolean false" | debconf-set-selections && \
-    DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash) || \
-    echo "Skipping dash reconfigure (not applicable)"
-
-# Install the repo tool to handle git submodules (meta layers) comfortably.
-ADD https://storage.googleapis.com/git-repo-downloads/repo /usr/local/bin/
-RUN chmod 755 /usr/local/bin/repo
-
-# Set the locale to en_US.UTF-8, because the Yocto build fails without any locale set.
-RUN locale-gen en_US.UTF-8 && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
-
-# Add user "embeddeduse" to sudoers. Then, the user can install Linux packages in the container.
-ENV USER_NAME embeddeduse
-RUN echo "${USER_NAME} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/${USER_NAME} && \
-    chmod 0440 /etc/sudoers.d/${USER_NAME}
-
-# The running container writes all the build artefacts to a host directory (outside the container).
-# The container can only write files to host directories, if it uses the same user ID and
-# group ID owning the host directories. The host_uid and group_uid are passed to the docker build
-# command with the --build-arg option. By default, they are both 1001. The docker image creates
-# a group with host_gid and a user with host_uid and adds the user to the group. The symbolic
-# name of the group and user is embeddeduse.
-ARG host_uid=1001
-ARG host_gid=1001
-RUN groupadd -g $host_gid $USER_NAME && useradd -g $host_gid -m -s /bin/bash -u $host_uid $USER_NAME
-
-# Perform the Yocto build as user embeddeduse (not as root).
-# By default, docker runs as root. However, Yocto builds should not be run as root, but as a
-# normal user. Hence, we switch to the newly created user embeddeduse.
-USER $USER_NAME
-
-WORKDIR /public/Work
+USER conan
+WORKDIR /home/conan

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,32 +1,57 @@
-FROM ubuntu:20.04
+# Use Ubuntu 18.04 LTS (Bionic Beaver) as the basis for the Docker image.
+FROM ubuntu:18.04
 
+# Install all Linux packages required for Yocto builds as given in section "Build Host Packages"
+# on https://www.yoctoproject.org/docs/3.0.2/brief-yoctoprojectqs/brief-yoctoprojectqs.html.
+# I added the package git-lfs, which I found missing during a Yocto build.
+# Without DEBIAN_FRONTEND=noninteractive, the image build hangs indefinitely
+# at "Configuring tzdata". Even if you answer the question about the time zone, it will
+# not proceed.
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    gawk wget git-core diffstat unzip texinfo gcc-multilib \
+    build-essential chrpath socat cpio python python3 python3-pip python3-pexpect \
+    xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev \
+    pylint3 xterm git-lfs
 
-RUN apt-get -qq update \
-    && apt-get -qq install -y --no-install-recommends --no-install-suggests \
-       git \
-       python3 \
-       python3-dev \
-       build-essential \
-       chrpath \
-       cpio \
-       diffstat \
-       file \
-       gawk \
-       wget \
-       lz4 \
-       zstd \
-       sudo \
-       locales \
-    && locale-gen en_US.UTF-8 \
-    && update-locale LANG=en_US.UTF-8 \
-    && groupadd _1001 -g 1001 \
-    && groupadd _1000 -g 1000 \
-    && groupadd _2000 -g 2000 \
-    && groupadd _999 -g 999 \
-    && useradd -ms /bin/bash conan -g _1001 -G _1000,_2000,_999 \
-    && printf "conan:conan" | chpasswd \
-    && adduser conan sudo \
-    && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers
+# These packages are not needed for the Yocto build but in this file below.
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
+    locales sudo
 
-USER conan
-WORKDIR /home/conan
+# By default, Ubuntu uses dash as an alias for sh. Dash does not support the source command
+# needed for setting up Yocto build environments. Use bash as an alias for sh.
+RUN which dash &> /dev/null && (\
+    echo "dash dash/sh boolean false" | debconf-set-selections && \
+    DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash) || \
+    echo "Skipping dash reconfigure (not applicable)"
+
+# Install the repo tool to handle git submodules (meta layers) comfortably.
+ADD https://storage.googleapis.com/git-repo-downloads/repo /usr/local/bin/
+RUN chmod 755 /usr/local/bin/repo
+
+# Set the locale to en_US.UTF-8, because the Yocto build fails without any locale set.
+RUN locale-gen en_US.UTF-8 && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+# Add user "embeddeduse" to sudoers. Then, the user can install Linux packages in the container.
+ENV USER_NAME embeddeduse
+RUN echo "${USER_NAME} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/${USER_NAME} && \
+    chmod 0440 /etc/sudoers.d/${USER_NAME}
+
+# The running container writes all the build artefacts to a host directory (outside the container).
+# The container can only write files to host directories, if it uses the same user ID and
+# group ID owning the host directories. The host_uid and group_uid are passed to the docker build
+# command with the --build-arg option. By default, they are both 1001. The docker image creates
+# a group with host_gid and a user with host_uid and adds the user to the group. The symbolic
+# name of the group and user is embeddeduse.
+ARG host_uid=1001
+ARG host_gid=1001
+RUN groupadd -g $host_gid $USER_NAME && useradd -g $host_gid -m -s /bin/bash -u $host_uid $USER_NAME
+
+# Perform the Yocto build as user embeddeduse (not as root).
+# By default, docker runs as root. However, Yocto builds should not be run as root, but as a
+# normal user. Hence, we switch to the newly created user embeddeduse.
+USER $USER_NAME
+
+WORKDIR /public/Work

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -5,7 +5,7 @@ node('Linux') {
         checkout scm
     }
 
-/*     def image = null
+    def image = null
     stage('Build docker image') {
         image = docker.build('meta-conan-validate', '-f .ci/Dockerfile .')
     }
@@ -24,9 +24,9 @@ node('Linux') {
                 yocto-check-layer -d --dependency meta-oe meta-python --with-software-layer-signature-check ${WORKSPACE}
             '''
         }
-    } */
+    }
 
-    def yocto_builder_image = null
+/*     def yocto_builder_image = null
     stage('Build yocto-builder docker image') {
         sh "docker build -t conan-io/yocto-builder:${env.BUILD_ID} .ci/yocto/"
     }
@@ -35,10 +35,11 @@ node('Linux') {
         try {
             sh "docker run -d -t --name yocto-builder-${env.BUILD_ID} conan-io/yocto-builder:${env.BUILD_ID}"
             sh "docker exec -t yocto-builder-${env.BUILD_ID} /bin/bash -c 'git clone --branch kirkstone --depth 1 git://git.yoctoproject.org/poky'"
+            sh "docker exec -t yocto-builder-${env.BUILD_ID} /bin/bash -c 'mkdir poky/conf && touch poky/conf/sanity.conf'"
             sh "docker exec -t yocto-builder-${env.BUILD_ID} /bin/bash -c 'source poky/oe-init-build-env && bitbake -k core-image-minimal'"
         } finally {
             sh "docker rm -f yocto-builder-${env.BUILD_ID} || true"
             sh "docker rmi -f conan-io/yocto-builder:${env.BUILD_ID} || true"
         }
-    }
+    } */
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -5,7 +5,7 @@ node('Linux') {
         checkout scm
     }
 
-    def image = null
+    /* def image = null
     stage('Build docker image') {
         image = docker.build('meta-conan-validate', '-f .ci/Dockerfile .')
     }
@@ -24,7 +24,7 @@ node('Linux') {
                 yocto-check-layer -d --dependency meta-oe meta-python --with-software-layer-signature-check ${WORKSPACE}
             '''
         }
-    }
+    } */
 
     def yocto_builder_image = null
     stage('Build yocto-builder docker image') {
@@ -40,7 +40,7 @@ node('Linux') {
 
             sh '''#!/bin/bash
             cd poky
-            touch conf/sanity.conf
+            touch build/conf/sanity.conf
             source oe-init-build-env && bitbake core-image-minimal
             '''
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -32,7 +32,7 @@ node('Linux') {
     }
 
     stage('Build yocto image') {
-        yocto_builder_image.inside {
+        yocto_builder_image.inside("--user conan") {
             sh '''
             git clone git://git.yoctoproject.org/poky && cd poky
             git checkout kirkstone

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -33,8 +33,7 @@ node('Linux') {
 
     stage('Build yocto image') {
         yocto_builder_image.inside {
-            sh "echo \"USER: ${USER}\""
-            sh "echo \"PWD: ${PWD}\""
+            sh "export"
             sh 'git clone --branch kirkstone --depth 1 git://git.yoctoproject.org/poky'
 
             sh '''#!/bin/bash

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -25,4 +25,23 @@ node('Linux') {
             '''
         }
     }
+
+    def yocto_builder_image = null
+    stage('Build yocto-builder docker image') {
+        yocto_builder_image = docker.build('yocto-builder', '-f .ci/yocto/Dockerfile .')
+    }
+
+    stage('Build yocto image') {
+        yocto_builder_image.inside {
+            sh '''
+            git clone git://git.yoctoproject.org/poky && cd poky
+            git checkout kirkstone
+            '''
+
+            sh '''
+            source oe-init-build-env
+            bitbake core-image-minimal
+            '''
+        }
+    }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -5,7 +5,7 @@ node('Linux') {
         checkout scm
     }
 
-    /* def image = null
+    def image = null
     stage('Build docker image') {
         image = docker.build('meta-conan-validate', '-f .ci/Dockerfile .')
     }
@@ -24,9 +24,9 @@ node('Linux') {
                 yocto-check-layer -d --dependency meta-oe meta-python --with-software-layer-signature-check ${WORKSPACE}
             '''
         }
-    } */
+    }
 
-    def yocto_builder_image = null
+/*     def yocto_builder_image = null
     stage('Build yocto-builder docker image') {
         sh "docker build -t conan-io/yocto-builder:${env.BUILD_ID} .ci/yocto/"
     }
@@ -41,5 +41,5 @@ node('Linux') {
             sh "docker rm -f yocto-builder-${env.BUILD_ID} || true"
             sh "docker rmi -f conan-io/yocto-builder:${env.BUILD_ID} || true"
         }
-    }
+    } */
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -36,8 +36,10 @@ node('Linux') {
             sh 'su - conan'
             sh 'git clone --branch kirkstone --depth 1 git://git.yoctoproject.org/poky'
             sh 'mkdir poky/conf && touch poky/conf/sanity.conf'
-            sh 'source poky/oe-init-build-env'
-            sh 'bitbake -k core-image-minimal'
+            sh '''#!/bin/bash
+            source poky/oe-init-build-env
+            bitbake -k core-image-minimal
+            '''
         }
     }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -28,7 +28,7 @@ node('Linux') {
 
     def yocto_builder_image = null
     stage('Build yocto-builder docker image') {
-        sh "docker build -t conan-io/yocto-builder:${env.BUILD_ID} -f .ci/yocto/Dockerfile ."
+        sh "docker build -t conan-io/yocto-builder:${env.BUILD_ID} .ci/yocto/"
     }
 
     stage('Build yocto image') {

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -34,12 +34,15 @@ node('Linux') {
     stage('Build yocto image') {
         yocto_builder_image.inside {
             sh '''
+            echo "USER: ${USER}"
+            echo "PWD: ${PWD}"
             git clone --branch kirkstone --depth 1 git://git.yoctoproject.org/poky
             '''
 
             sh '''#!/bin/bash
             mkdir poky/conf && touch poky/conf/sanity.conf
-            source poky/oe-init-build-env && bitbake -k core-image-minimal
+            source poky/oe-init-build-env
+            bitbake -k core-image-minimal
             '''
         }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -33,12 +33,13 @@ node('Linux') {
 
     stage('Build yocto image') {
         try {
-            sh "docker run -d --name yocto-builder-${env.BUILD_ID} conan-io/yocto-builder:${env.BUILD_ID}"
+            sh "docker run -d -t --name yocto-builder-${env.BUILD_ID} conan-io/yocto-builder:${env.BUILD_ID}"
             sh "docker exec -t yocto-builder-${env.BUILD_ID} /bin/bash -c 'git clone --branch kirkstone --depth 1 git://git.yoctoproject.org/poky'"
             sh "docker exec -t yocto-builder-${env.BUILD_ID} /bin/bash -c 'mkdir poky/conf && touch poky/conf/sanity.conf'"
             sh "docker exec -t yocto-builder-${env.BUILD_ID} /bin/bash -c 'source poky/oe-init-build-env && bitbake -k core-image-minimal'"
         } finally {
             sh "docker rm -f yocto-builder-${env.BUILD_ID} || true"
+            sh "docker rmi -f conan-io/yocto-builder:${env.BUILD_ID} || true"
         }
     }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -26,7 +26,7 @@ node('Linux') {
         }
     }
 
-/*     def yocto_builder_image = null
+    def yocto_builder_image = null
     stage('Build yocto-builder docker image') {
         sh "docker build -t conan-io/yocto-builder:${env.BUILD_ID} .ci/yocto/"
     }
@@ -41,5 +41,5 @@ node('Linux') {
             sh "docker rm -f yocto-builder-${env.BUILD_ID} || true"
             sh "docker rmi -f conan-io/yocto-builder:${env.BUILD_ID} || true"
         }
-    } */
+    }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -32,7 +32,7 @@ node('Linux') {
     }
 
     stage('Build yocto image') {
-        yocto_builder_image.inside("--user conan") {
+        yocto_builder_image.inside {
             sh '''
             git clone git://git.yoctoproject.org/poky && cd poky
             git checkout kirkstone

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -39,6 +39,7 @@ node('Linux') {
             '''
 
             sh '''#!/bin/bash
+            cd poky
             source oe-init-build-env
             bitbake core-image-minimal
             '''

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -35,6 +35,9 @@ node('Linux') {
         yocto_builder_image.inside {
             sh '''
             git clone --branch kirkstone --depth 1 git://git.yoctoproject.org/poky
+            '''
+
+            sh '''#!/bin/bash
             mkdir poky/conf && touch poky/conf/sanity.conf
             source poky/oe-init-build-env
             bitbake -k core-image-minimal

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -5,7 +5,7 @@ node('Linux') {
         checkout scm
     }
 
-    def image = null
+/*     def image = null
     stage('Build docker image') {
         image = docker.build('meta-conan-validate', '-f .ci/Dockerfile .')
     }
@@ -24,9 +24,9 @@ node('Linux') {
                 yocto-check-layer -d --dependency meta-oe meta-python --with-software-layer-signature-check ${WORKSPACE}
             '''
         }
-    }
+    } */
 
-/*     def yocto_builder_image = null
+    def yocto_builder_image = null
     stage('Build yocto-builder docker image') {
         sh "docker build -t conan-io/yocto-builder:${env.BUILD_ID} .ci/yocto/"
     }
@@ -35,11 +35,10 @@ node('Linux') {
         try {
             sh "docker run -d -t --name yocto-builder-${env.BUILD_ID} conan-io/yocto-builder:${env.BUILD_ID}"
             sh "docker exec -t yocto-builder-${env.BUILD_ID} /bin/bash -c 'git clone --branch kirkstone --depth 1 git://git.yoctoproject.org/poky'"
-            sh "docker exec -t yocto-builder-${env.BUILD_ID} /bin/bash -c 'mkdir poky/conf && touch poky/conf/sanity.conf'"
             sh "docker exec -t yocto-builder-${env.BUILD_ID} /bin/bash -c 'source poky/oe-init-build-env && bitbake -k core-image-minimal'"
         } finally {
             sh "docker rm -f yocto-builder-${env.BUILD_ID} || true"
             sh "docker rmi -f conan-io/yocto-builder:${env.BUILD_ID} || true"
         }
-    } */
+    }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -33,7 +33,7 @@ node('Linux') {
 
     stage('Build yocto image') {
         try {
-            sh "docker run -d --name yocto-builder-${env.BUILD_ID} conan-io/yocto-builder:${env.BUILD_ID} tail -f /dev/null"
+            sh "docker run -d --name yocto-builder-${env.BUILD_ID} conan-io/yocto-builder:${env.BUILD_ID}"
             sh "docker exec -it yocto-builder-${env.BUILD_ID} /bin/bash -c 'git clone --branch kirkstone --depth 1 git://git.yoctoproject.org/poky'"
             sh "docker exec -it yocto-builder-${env.BUILD_ID} /bin/bash -c 'mkdir poky/conf && touch poky/conf/sanity.conf'"
             sh "docker exec -it yocto-builder-${env.BUILD_ID} /bin/bash -c 'source poky/oe-init-build-env && bitbake -k core-image-minimal'"

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -40,6 +40,7 @@ node('Linux') {
 
             sh '''#!/bin/bash
             cd poky
+            touch conf/sanity.conf
             source oe-init-build-env && bitbake core-image-minimal
             '''
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -40,8 +40,7 @@ node('Linux') {
 
             sh '''#!/bin/bash
             cd poky
-            source oe-init-build-env
-            bitbake core-image-minimal
+            source oe-init-build-env && bitbake core-image-minimal
             '''
         }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -28,16 +28,14 @@ node('Linux') {
 
     def yocto_builder_image = null
     stage('Build yocto-builder docker image') {
-        yocto_builder_image = docker.build('yocto-builder', '-f .ci/yocto/Dockerfile .')
+        yocto_builder_image = docker.build('conan-io/yocto-builder:${env.BUILD_ID}', '-f .ci/yocto/Dockerfile .')
     }
 
     stage('Build yocto image') {
         yocto_builder_image.inside {
-            sh '''
-            echo "USER: ${USER}"
-            echo "PWD: ${PWD}"
-            git clone --branch kirkstone --depth 1 git://git.yoctoproject.org/poky
-            '''
+            sh 'echo "USER: ${USER}"'
+            sh 'echo "PWD: ${PWD}"'
+            sh 'git clone --branch kirkstone --depth 1 git://git.yoctoproject.org/poky'
 
             sh '''#!/bin/bash
             mkdir poky/conf && touch poky/conf/sanity.conf

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -28,18 +28,17 @@ node('Linux') {
 
     def yocto_builder_image = null
     stage('Build yocto-builder docker image') {
-        yocto_builder_image = docker.build("conan-io/yocto-builder:${env.BUILD_ID}", '-f .ci/yocto/Dockerfile .')
+        sh "docker build -t conan-io/yocto-builder:${env.BUILD_ID} -f .ci/yocto/Dockerfile ."
     }
 
     stage('Build yocto image') {
-        yocto_builder_image.inside {
-            sh 'su - conan'
-            sh 'git clone --branch kirkstone --depth 1 git://git.yoctoproject.org/poky'
-            sh 'mkdir poky/conf && touch poky/conf/sanity.conf'
-            sh '''#!/bin/bash
-            source poky/oe-init-build-env
-            bitbake -k core-image-minimal
-            '''
+        try {
+            sh "docker run -d --name yocto-builder-${env.BUILD_ID} conan-io/yocto-builder:${env.BUILD_ID} tail -f /dev/null"
+            sh "docker exec -it yocto-builder-${env.BUILD_ID} /bin/bash -c 'git clone --branch kirkstone --depth 1 git://git.yoctoproject.org/poky'"
+            sh "docker exec -it yocto-builder-${env.BUILD_ID} /bin/bash -c 'mkdir poky/conf && touch poky/conf/sanity.conf'"
+            sh "docker exec -it yocto-builder-${env.BUILD_ID} /bin/bash -c 'source poky/oe-init-build-env && bitbake -k core-image-minimal'"
+        } finally {
+            sh "docker rm -f yocto-builder-${env.BUILD_ID} || true"
         }
     }
 }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -38,7 +38,7 @@ node('Linux') {
             git checkout kirkstone
             '''
 
-            sh '''
+            sh '''#!/bin/bash
             source oe-init-build-env
             bitbake core-image-minimal
             '''

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -34,9 +34,9 @@ node('Linux') {
     stage('Build yocto image') {
         try {
             sh "docker run -d --name yocto-builder-${env.BUILD_ID} conan-io/yocto-builder:${env.BUILD_ID}"
-            sh "docker exec -it yocto-builder-${env.BUILD_ID} /bin/bash -c 'git clone --branch kirkstone --depth 1 git://git.yoctoproject.org/poky'"
-            sh "docker exec -it yocto-builder-${env.BUILD_ID} /bin/bash -c 'mkdir poky/conf && touch poky/conf/sanity.conf'"
-            sh "docker exec -it yocto-builder-${env.BUILD_ID} /bin/bash -c 'source poky/oe-init-build-env && bitbake -k core-image-minimal'"
+            sh "docker exec -t yocto-builder-${env.BUILD_ID} /bin/bash -c 'git clone --branch kirkstone --depth 1 git://git.yoctoproject.org/poky'"
+            sh "docker exec -t yocto-builder-${env.BUILD_ID} /bin/bash -c 'mkdir poky/conf && touch poky/conf/sanity.conf'"
+            sh "docker exec -t yocto-builder-${env.BUILD_ID} /bin/bash -c 'source poky/oe-init-build-env && bitbake -k core-image-minimal'"
         } finally {
             sh "docker rm -f yocto-builder-${env.BUILD_ID} || true"
         }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -39,8 +39,7 @@ node('Linux') {
 
             sh '''#!/bin/bash
             mkdir poky/conf && touch poky/conf/sanity.conf
-            source poky/oe-init-build-env
-            bitbake -k core-image-minimal
+            source poky/oe-init-build-env && bitbake -k core-image-minimal
             '''
         }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -40,8 +40,8 @@ node('Linux') {
 
             sh '''#!/bin/bash
             cd poky
-            touch build/conf/sanity.conf
-            source oe-init-build-env && bitbake core-image-minimal
+            mkdir conf && touch conf/sanity.conf
+            source oe-init-build-env && bitbake -k core-image-minimal
             '''
         }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -34,14 +34,10 @@ node('Linux') {
     stage('Build yocto image') {
         yocto_builder_image.inside {
             sh '''
-            git clone git://git.yoctoproject.org/poky && cd poky
-            git checkout kirkstone
-            '''
-
-            sh '''#!/bin/bash
-            cd poky
-            mkdir conf && touch conf/sanity.conf
-            source oe-init-build-env && bitbake -k core-image-minimal
+            git clone --branch kirkstone --depth 1 git://git.yoctoproject.org/poky
+            mkdir poky/conf && touch poky/conf/sanity.conf
+            source poky/oe-init-build-env
+            bitbake -k core-image-minimal
             '''
         }
     }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -28,13 +28,13 @@ node('Linux') {
 
     def yocto_builder_image = null
     stage('Build yocto-builder docker image') {
-        yocto_builder_image = docker.build('conan-io/yocto-builder:${env.BUILD_ID}', '-f .ci/yocto/Dockerfile .')
+        yocto_builder_image = docker.build("conan-io/yocto-builder:${env.BUILD_ID}", '-f .ci/yocto/Dockerfile .')
     }
 
     stage('Build yocto image') {
         yocto_builder_image.inside {
-            sh 'echo "USER: ${USER}"'
-            sh 'echo "PWD: ${PWD}"'
+            sh "echo \"USER: ${USER}\""
+            sh "echo \"PWD: ${PWD}\""
             sh 'git clone --branch kirkstone --depth 1 git://git.yoctoproject.org/poky'
 
             sh '''#!/bin/bash

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -33,14 +33,11 @@ node('Linux') {
 
     stage('Build yocto image') {
         yocto_builder_image.inside {
-            sh "export"
+            sh 'su - conan'
             sh 'git clone --branch kirkstone --depth 1 git://git.yoctoproject.org/poky'
-
-            sh '''#!/bin/bash
-            mkdir poky/conf && touch poky/conf/sanity.conf
-            source poky/oe-init-build-env
-            bitbake -k core-image-minimal
-            '''
+            sh 'mkdir poky/conf && touch poky/conf/sanity.conf'
+            sh 'source poky/oe-init-build-env'
+            sh 'bitbake -k core-image-minimal'
         }
     }
 }

--- a/.ci/yocto/Dockerfile
+++ b/.ci/yocto/Dockerfile
@@ -21,12 +21,19 @@ RUN chmod a+x /usr/local/bin/repo
 # Create user "jenkins"
 # RUN id jenkins 2>/dev/null || useradd --uid 1000 --create-home jenkins
 
-RUN groupadd --gid 1000 build \
-    && useradd --uid 1000 --gid 1000 -m build
+#RUN groupadd --gid 1000 build \
+#    && useradd --uid 1000 --gid 1000 -m build
 # Create a non-root user that will perform the actual build
 #RUN id build 2>/dev/null || useradd --uid 30000 --create-home build
 #RUN apt-get install -y sudo
 #RUN echo "build ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers
+
+RUN groupadd _1001 -g 1001 \
+    && groupadd _1000 -g 1000 \
+    && groupadd _2000 -g 2000 \
+    && groupadd _999 -g 999 \
+    && useradd -ms /bin/bash conan -g _1001 -G _1000,_2000,_999 \
+    && printf "conan:conan" | chpasswd
 
 # Fix error "Please use a locale setting which supports utf-8."
 # See https://wiki.yoctoproject.org/wiki/TipsAndTricks/ResolvingLocaleIssues
@@ -40,6 +47,6 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
-USER build
-WORKDIR /home/build
+USER conan
+WORKDIR /home/conan
 CMD "/bin/bash"

--- a/.ci/yocto/Dockerfile
+++ b/.ci/yocto/Dockerfile
@@ -2,17 +2,17 @@ FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && apt-get -y upgrade
+RUN apt-get -qq update && apt-get -y upgrade
 
 # Required Packages for the Host Development System
 # http://www.yoctoproject.org/docs/latest/mega-manual/mega-manual.html#required-packages-for-the-host-development-system
-RUN apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib \
+RUN apt-get install -y --no-install-suggests --no-install-recommends gawk wget git-core diffstat unzip texinfo gcc-multilib \
         build-essential chrpath socat cpio python3 python3-pip python3-pexpect python-is-python3 \
         xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev \
         pylint3 xterm xterm zstd liblz4-tool
 
 # Additional host packages required by poky/scripts/wic
-RUN apt-get install -y curl dosfstools mtools parted syslinux tree zip
+RUN apt-get install -y --no-install-suggests --no-install-recommends curl dosfstools mtools parted syslinux tree zip
 
 # Add "repo" tool (used by many Yocto-based projects)
 RUN curl http://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo
@@ -34,15 +34,22 @@ RUN groupadd _1001 -g 1001 \
     && groupadd _999 -g 999 \
     && useradd -ms /bin/bash conan -g _1001 -G _1000,_2000,_999 \
     && printf "conan:conan" | chpasswd \
+    && adduser conan sudo \
     && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers
 
 # Fix error "Please use a locale setting which supports utf-8."
 # See https://wiki.yoctoproject.org/wiki/TipsAndTricks/ResolvingLocaleIssues
-RUN apt-get install -y locales
+RUN apt-get install -y --no-install-suggests --no-install-recommends locales
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
         echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
         dpkg-reconfigure --frontend=noninteractive locales && \
         update-locale LANG=en_US.UTF-8
+
+ # Remove APT cache
+ RUN apt-get -qq autoremove -y \
+        && apt-get -qq autoclean \
+        && apt-get -qq update \
+        && rm -rf /var/lib/apt/lists/*
 
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8

--- a/.ci/yocto/Dockerfile
+++ b/.ci/yocto/Dockerfile
@@ -1,0 +1,5 @@
+FROM gmacario/build-yocto
+
+
+RUN apt-get update -y
+RUN apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib build-essential chrpath socat libsdl1.2-dev xterm zstd liblz4-tool

--- a/.ci/yocto/Dockerfile
+++ b/.ci/yocto/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -qq update && apt-get -y upgrade
 RUN apt-get install -y --no-install-suggests --no-install-recommends gawk wget git-core diffstat unzip texinfo gcc-multilib \
         build-essential chrpath socat cpio python3 python3-pip python3-pexpect python-is-python3 \
         xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev \
-        pylint3 xterm xterm zstd liblz4-tool
+        pylint3 xterm xterm zstd liblz4-tool file sudo
 
 # Additional host packages required by poky/scripts/wic
 RUN apt-get install -y --no-install-suggests --no-install-recommends curl dosfstools mtools parted syslinux tree zip
@@ -17,6 +17,16 @@ RUN apt-get install -y --no-install-suggests --no-install-recommends curl dosfst
 # Add "repo" tool (used by many Yocto-based projects)
 RUN curl http://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo
 RUN chmod a+x /usr/local/bin/repo
+
+# Create user "jenkins"
+# RUN id jenkins 2>/dev/null || useradd --uid 1000 --create-home jenkins
+
+#RUN groupadd --gid 1000 build \
+#    && useradd --uid 1000 --gid 1000 -m build
+# Create a non-root user that will perform the actual build
+#RUN id build 2>/dev/null || useradd --uid 30000 --create-home build
+#RUN apt-get install -y sudo
+#RUN echo "build ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers
 
 RUN groupadd _1001 -g 1001 \
     && groupadd _1000 -g 1000 \

--- a/.ci/yocto/Dockerfile
+++ b/.ci/yocto/Dockerfile
@@ -1,5 +1,47 @@
-FROM gmacario/build-yocto
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get -y upgrade
+
+# Required Packages for the Host Development System
+# http://www.yoctoproject.org/docs/latest/mega-manual/mega-manual.html#required-packages-for-the-host-development-system
+RUN apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib \
+        build-essential chrpath socat cpio python3 python3-pip python3-pexpect python-is-python3 \
+        xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev \
+        pylint3 xterm
+
+# Additional host packages required by poky/scripts/wic
+RUN apt-get install -y curl dosfstools mtools parted syslinux tree zip
+
+# Add "repo" tool (used by many Yocto-based projects)
+RUN curl http://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo
+RUN chmod a+x /usr/local/bin/repo
+
+# Create user "jenkins"
+RUN id jenkins 2>/dev/null || useradd --uid 1000 --create-home jenkins
+
+# Create a non-root user that will perform the actual build
+RUN id build 2>/dev/null || useradd --uid 30000 --create-home build
+RUN apt-get install -y sudo
+RUN echo "build ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers
+
+# Fix error "Please use a locale setting which supports utf-8."
+# See https://wiki.yoctoproject.org/wiki/TipsAndTricks/ResolvingLocaleIssues
+RUN apt-get install -y locales
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+        echo 'LANG="en_US.UTF-8"'>/etc/default/locale && \
+        dpkg-reconfigure --frontend=noninteractive locales && \
+        update-locale LANG=en_US.UTF-8
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+USER build
+WORKDIR /home/build
+CMD "/bin/bash"
 
 
-RUN apt-get update -y
-RUN apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib build-essential chrpath socat libsdl1.2-dev xterm zstd liblz4-tool
+RUN sudo apt-get update -y
+RUN sudo apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib build-essential chrpath socat libsdl1.2-dev xterm zstd liblz4-tool

--- a/.ci/yocto/Dockerfile
+++ b/.ci/yocto/Dockerfile
@@ -18,16 +18,6 @@ RUN apt-get install -y --no-install-suggests --no-install-recommends curl dosfst
 RUN curl http://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo
 RUN chmod a+x /usr/local/bin/repo
 
-# Create user "jenkins"
-# RUN id jenkins 2>/dev/null || useradd --uid 1000 --create-home jenkins
-
-#RUN groupadd --gid 1000 build \
-#    && useradd --uid 1000 --gid 1000 -m build
-# Create a non-root user that will perform the actual build
-#RUN id build 2>/dev/null || useradd --uid 30000 --create-home build
-#RUN apt-get install -y sudo
-#RUN echo "build ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers
-
 RUN groupadd _1001 -g 1001 \
     && groupadd _1000 -g 1000 \
     && groupadd _2000 -g 2000 \

--- a/.ci/yocto/Dockerfile
+++ b/.ci/yocto/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -qq update && apt-get -y upgrade
 RUN apt-get install -y --no-install-suggests --no-install-recommends gawk wget git-core diffstat unzip texinfo gcc-multilib \
         build-essential chrpath socat cpio python3 python3-pip python3-pexpect python-is-python3 \
         xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev \
-        pylint3 xterm xterm zstd liblz4-tool file sudo
+        pylint3 xterm xterm zstd liblz4-tool
 
 # Additional host packages required by poky/scripts/wic
 RUN apt-get install -y --no-install-suggests --no-install-recommends curl dosfstools mtools parted syslinux tree zip
@@ -17,16 +17,6 @@ RUN apt-get install -y --no-install-suggests --no-install-recommends curl dosfst
 # Add "repo" tool (used by many Yocto-based projects)
 RUN curl http://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo
 RUN chmod a+x /usr/local/bin/repo
-
-# Create user "jenkins"
-# RUN id jenkins 2>/dev/null || useradd --uid 1000 --create-home jenkins
-
-#RUN groupadd --gid 1000 build \
-#    && useradd --uid 1000 --gid 1000 -m build
-# Create a non-root user that will perform the actual build
-#RUN id build 2>/dev/null || useradd --uid 30000 --create-home build
-#RUN apt-get install -y sudo
-#RUN echo "build ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers
 
 RUN groupadd _1001 -g 1001 \
     && groupadd _1000 -g 1000 \

--- a/.ci/yocto/Dockerfile
+++ b/.ci/yocto/Dockerfile
@@ -33,7 +33,8 @@ RUN groupadd _1001 -g 1001 \
     && groupadd _2000 -g 2000 \
     && groupadd _999 -g 999 \
     && useradd -ms /bin/bash conan -g _1001 -G _1000,_2000,_999 \
-    && printf "conan:conan" | chpasswd
+    && printf "conan:conan" | chpasswd \
+    && printf "conan ALL= NOPASSWD: ALL\\n" >> /etc/sudoers
 
 # Fix error "Please use a locale setting which supports utf-8."
 # See https://wiki.yoctoproject.org/wiki/TipsAndTricks/ResolvingLocaleIssues

--- a/.ci/yocto/Dockerfile
+++ b/.ci/yocto/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -qq update && apt-get -y upgrade
 RUN apt-get install -y --no-install-suggests --no-install-recommends gawk wget git-core diffstat unzip texinfo gcc-multilib \
         build-essential chrpath socat cpio python3 python3-pip python3-pexpect python-is-python3 \
         xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev \
-        pylint3 xterm xterm zstd liblz4-tool
+        pylint3 xterm xterm zstd liblz4-tool file sudo
 
 # Additional host packages required by poky/scripts/wic
 RUN apt-get install -y --no-install-suggests --no-install-recommends curl dosfstools mtools parted syslinux tree zip
@@ -57,4 +57,4 @@ ENV LANGUAGE en_US.UTF-8
 
 USER conan
 WORKDIR /home/conan
-CMD "/bin/bash"
+CMD [ "/bin/bash" ]

--- a/.ci/yocto/Dockerfile
+++ b/.ci/yocto/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get -y upgrade
 RUN apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib \
         build-essential chrpath socat cpio python3 python3-pip python3-pexpect python-is-python3 \
         xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev \
-        pylint3 xterm
+        pylint3 xterm xterm zstd liblz4-tool
 
 # Additional host packages required by poky/scripts/wic
 RUN apt-get install -y curl dosfstools mtools parted syslinux tree zip
@@ -19,12 +19,14 @@ RUN curl http://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/
 RUN chmod a+x /usr/local/bin/repo
 
 # Create user "jenkins"
-RUN id jenkins 2>/dev/null || useradd --uid 1000 --create-home jenkins
+# RUN id jenkins 2>/dev/null || useradd --uid 1000 --create-home jenkins
 
+RUN groupadd --gid 1000 build \
+    && useradd --uid 1000 --gid 1000 -m build
 # Create a non-root user that will perform the actual build
-RUN id build 2>/dev/null || useradd --uid 30000 --create-home build
-RUN apt-get install -y sudo
-RUN echo "build ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers
+#RUN id build 2>/dev/null || useradd --uid 30000 --create-home build
+#RUN apt-get install -y sudo
+#RUN echo "build ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers
 
 # Fix error "Please use a locale setting which supports utf-8."
 # See https://wiki.yoctoproject.org/wiki/TipsAndTricks/ResolvingLocaleIssues
@@ -41,7 +43,3 @@ ENV LANGUAGE en_US.UTF-8
 USER build
 WORKDIR /home/build
 CMD "/bin/bash"
-
-
-RUN sudo apt-get update -y
-RUN sudo apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib build-essential chrpath socat libsdl1.2-dev xterm zstd liblz4-tool


### PR DESCRIPTION
Add CI stage to build a minimal yocto image (it would be slow but at least it would be tested)

In the future we can incorporate:
- Proper per branch testing for every yocto version we support (kirkstone added in this PR as default -not relevant right now-)
- The conan meta layer to the image build.
- Steps that reproduce the documentation of yocto in conan.