### PR TITLE
[fix] Add maintainers section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ This layer depends on the `meta-python` layer: https://layers.openembedded.org/l
 License
 -------
 [MIT](https://github.com/conan-io/conan/blob/develop/LICENSE.md)
+
+Maintainer
+----------
+[conan.io](https://conan.io)


### PR DESCRIPTION
Saw this in CI and would like to make it happy:

```
INFO: test_readme (common.CommonCheckLayer)

INFO:  ... FAIL

INFO: Traceback (most recent call last):

  File "/tmp/poky/scripts/lib/checklayer/cases/common.py", line 37, in test_readme

    self.assertIn('maintainer', data.lower())

AssertionError: 'maintainer' not found in '# meta conan\n\n[![build status]
```

This section seems to be a common practice in yocto layers repos: https://github.com/96boards/meta-96boards